### PR TITLE
Enable V-level to be set

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -21,14 +21,23 @@
 package klog
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
 	"go.uber.org/zap"
 )
 
-// Verbosity, 0-10 level of logging
-var Verbosity = 10
+var verbosity = 10
+
+// InitFlags is for explicitly initializing the flags.
+func InitFlags(flagset *flag.FlagSet) {
+	if flagset == nil {
+		return
+	}
+
+	flagset.IntVar(&verbosity, "v", 10, "level 0-10 of verbosity, increasing")
+}
 
 // Level is a shim
 type Level int32
@@ -43,7 +52,7 @@ func Flush() {
 
 // V is a shim
 func V(level Level) Verbose {
-	return Verbose(int(level) <= Verbosity && zap.L().Core().Enabled(zap.DebugLevel))
+	return Verbose(int(level) <= verbosity && zap.L().Core().Enabled(zap.DebugLevel))
 }
 
 // Info is a shim

--- a/klog.go
+++ b/klog.go
@@ -27,6 +27,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// Verbosity, 0-10 level of logging
+var Verbosity = 10
+
 // Level is a shim
 type Level int32
 
@@ -40,23 +43,29 @@ func Flush() {
 
 // V is a shim
 func V(level Level) Verbose {
-	return Verbose(zap.L().Core().Enabled(zap.DebugLevel))
+	return Verbose(int(level) <= Verbosity && zap.L().Core().Enabled(zap.DebugLevel))
 }
 
 // Info is a shim
 func (v Verbose) Info(args ...interface{}) {
-	zap.S().Debug(args...)
+	if v {
+		zap.S().Debug(args...)
+	}
 }
 
 // Infoln is a shim
 func (v Verbose) Infoln(args ...interface{}) {
-	s := fmt.Sprint(args...)
-	zap.S().Debug(s, "\n")
+	if v {
+		s := fmt.Sprint(args...)
+		zap.S().Debug(s, "\n")
+	}
 }
 
 // Infof is a shim
 func (v Verbose) Infof(format string, args ...interface{}) {
-	zap.S().Debugf(format, args...)
+	if v {
+		zap.S().Debugf(format, args...)
+	}
 }
 
 // Info is a shim

--- a/klog.go
+++ b/klog.go
@@ -55,7 +55,8 @@ func (l *Level) Set(value string) error {
 		return err
 	}
 
-	verbosity = v
+	verbosity = int(v)
+	return nil
 }
 
 // Verbose is a shim

--- a/klog.go
+++ b/klog.go
@@ -24,6 +24,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 
 	"go.uber.org/zap"
 )
@@ -41,6 +42,21 @@ func InitFlags(flagset *flag.FlagSet) {
 
 // Level is a shim
 type Level int32
+
+// Get is part of the flag.Value interface.
+func (l *Level) Get() interface{} {
+	return *l
+}
+
+// Used to set global verbosity level
+func (l *Level) Set(value string) error {
+	v, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return err
+	}
+
+	verbosity = v
+}
 
 // Verbose is a shim
 type Verbose bool

--- a/klog.go
+++ b/klog.go
@@ -69,7 +69,10 @@ func Flush() {
 
 // V is a shim
 func V(level Level) Verbose {
-	return Verbose(int(level) <= verbosity && zap.L().Core().Enabled(zap.DebugLevel))
+	l := int(level)
+	v := verbosity
+	isEnabled := zap.L().Core().Enabled(zap.DebugLevel)
+	return Verbose(l <= v && isEnabled)
 }
 
 // Info is a shim


### PR DESCRIPTION
Also, only log when V-level enables logging (doesn't make much sense not to check).

Choose to do it like klog so it's easier to move from using klog to the shim, if multiple repos are using the same logging library in a third repo.